### PR TITLE
Resolve "Implement functionality for performing a train-test split on the extracted IDs and saving data for the two sets of IDs to separate 'train' and 'test' files"

### DIFF
--- a/mimic_iii_explorer_client/__main__.py
+++ b/mimic_iii_explorer_client/__main__.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
+from sklearn.model_selection import train_test_split
+
 sys.path.append(os.path.join(os.path.dirname(__file__), "client/gen"))
 
 import argparse  # noqa: E402
@@ -12,7 +14,7 @@ from mimic_iii_explorer_client.extraction.clinical_text_extraction.clinical_text
 from mimic_iii_explorer_client.extraction.id_retrieval.id_retrieval import retrieve_ids  # noqa: E402
 from mimic_iii_explorer_client.extraction.target_extraction.target_extraction import extract_target  # noqa: E402
 from mimic_iii_explorer_client.request_spec_parsing.parsing import parse_request_spec_clinical_text, parse_request_spec_ids, parse_request_spec_target  # noqa: E402
-from mimic_iii_explorer_client.utils.cli_args_types import dir_path  # noqa: E402
+from mimic_iii_explorer_client.utils.cli_args_types import dir_path, train_size  # noqa: E402
 from mimic_iii_explorer_client.utils.utils import limit_ids  # noqa: E402
 
 
@@ -27,6 +29,7 @@ def main(args):
     clinical_text_extraction_spec_parser.add_argument('--clinical-text-spec-path', type=str, required=True)
     clinical_text_extraction_spec_parser.add_argument('--target-spec-path', type=str, required=True)
     clinical_text_extraction_spec_parser.add_argument('--limit-ids', default=1.0, help='Number or percentage of root entity idss to consider')
+    clinical_text_extraction_spec_parser.add_argument('--test-size', type=train_size, help='Test set size (no train-test split is performed if not specified)')
     clinical_text_extraction_spec_parser.add_argument('--output-format', type=str, default=TextOutputFormat.FAST_TEXT.value,
                                                       choices=[v.value for v in TextOutputFormat], help='Output format')
     clinical_text_extraction_spec_parser.add_argument('--output-dir', type=dir_path, default='.', help='Directory in which to store the outputs')
@@ -42,18 +45,27 @@ def main(args):
         retrieved_ids = retrieve_ids(id_retrieval_spec)
 
         # limit ids
-        ids_limitd = limit_ids(retrieved_ids, parsed_args['limit_ids'])
+        ids_limited = limit_ids(retrieved_ids, parsed_args['limit_ids'])
 
-        # extract target values
-        target_extraction_spec = parse_request_spec_target(parsed_args['target_spec_path'], ids_limitd)
-        extracted_target = extract_target(target_extraction_spec)
+        def get_target_and_text(ids, output_file_suffix):
+            # extract target values
+            target_extraction_spec = parse_request_spec_target(parsed_args['target_spec_path'], ids)
+            extracted_target = extract_target(target_extraction_spec)
 
-        # extract clinical text
-        clinical_text_config = parse_request_spec_clinical_text(parsed_args['clinical_text_spec_path'], list(map(lambda x: x.root_entity_id, extracted_target)))
-        extracted_texts = extract_clinical_text(clinical_text_config)
+            # extract clinical text
+            clinical_text_config = parse_request_spec_clinical_text(parsed_args['clinical_text_spec_path'], list(map(lambda x: x.root_entity_id, extracted_target)))
+            extracted_texts = extract_clinical_text(clinical_text_config)
 
-        # pre-process and save clinical text
-        save.save_clinical_text(extracted_texts, extracted_target, parsed_args['output_format'], parsed_args['output_dir'], preprocessing_steps=None)
+            # pre-process and save clinical text
+            save.save_clinical_text(extracted_texts, extracted_target, parsed_args['output_format'], parsed_args['output_dir'], output_file_suffix, preprocessing_steps=None)
+
+        if parsed_args['test_size'] is not None:
+            ids_limited_train, ids_limited_test = train_test_split(ids_limited, test_size=parsed_args['test_size'], random_state=42)
+            get_target_and_text(ids_limited_train, "-train")
+            get_target_and_text(ids_limited_test, "-test")
+        else:
+            get_target_and_text(ids_limited, None)
+
     else:
         raise NotImplementedError('Task {0} not implemented'.format(parsed_args['task']))
 

--- a/mimic_iii_explorer_client/data_saving/save.py
+++ b/mimic_iii_explorer_client/data_saving/save.py
@@ -3,8 +3,8 @@ import re
 import time
 from typing import List, Collection
 
-from mimic_iii_explorer_client import TextOutputFormat
 from generated_client import ClinicalTextResult, ExtractedTarget
+from mimic_iii_explorer_client import TextOutputFormat
 from mimic_iii_explorer_client.text_preprocessing.text_preprocessing import preprocess
 
 
@@ -12,6 +12,7 @@ def save_clinical_text(extracted_texts: List[ClinicalTextResult],
                        extracted_target: List[ExtractedTarget],
                        output_format: str,
                        output_dir: str,
+                       output_file_suffix: str,
                        preprocessing_steps: Collection[str] = None) -> None:
     """Save extracted clinical texts in specified format.
 
@@ -19,11 +20,12 @@ def save_clinical_text(extracted_texts: List[ClinicalTextResult],
     :param extracted_target: extracted target values (DTOs)
     :param output_format: output format specifier
     :param output_dir: output directory
+    :param output_file_suffix: suffix to add to the output filename
     :param preprocessing_steps: preprocessing steps (use all if set to None)
     """
     if output_format == TextOutputFormat.FAST_TEXT.value:
         _RE_COMBINE_WHITESPACE = re.compile(r"\s+")
-        with open(os.path.join(output_dir, 'data-' + time.strftime("%Y%m%d-%H%M%S") + '.txt'), 'w') as f:
+        with open(os.path.join(output_dir, 'data-' + time.strftime("%Y%m%d-%H%M%S") + (output_file_suffix if output_file_suffix else "") + '.txt'), 'w') as f:
             for extracted_text in extracted_texts:
                 # pre-process
                 text = _RE_COMBINE_WHITESPACE.sub(' ', extracted_text.text.replace('\n', ' ')).strip()

--- a/mimic_iii_explorer_client/test/integration/test_main.py
+++ b/mimic_iii_explorer_client/test/integration/test_main.py
@@ -11,7 +11,7 @@ class MyTestCase(unittest.TestCase):
     def __get_rel_path(rel_path):
         return os.path.join(os.path.dirname(__file__), rel_path)
 
-    def test_main(self):
+    def test_main_extract_clinical_text(self):
         args = [
             'extract-clinical-text',
             '--ids-spec-path', self.__get_rel_path('test-spec/ids_spec.json'),
@@ -28,3 +28,27 @@ class MyTestCase(unittest.TestCase):
         self.assertGreater(len(lines), 0)
 
         os.remove(file_path)
+
+    def test_main_extract_clinical_text_tt_split(self):
+        args = [
+            'extract-clinical-text',
+            '--ids-spec-path', self.__get_rel_path('test-spec/ids_spec.json'),
+            '--limit-ids', '0.01',
+            '--test-size', '0.2',
+            '--clinical-text-spec-path', self.__get_rel_path('test-spec/clinical_text_spec.json'),
+            '--target-spec-path', self.__get_rel_path('test-spec/target_spec.json')
+        ]
+        main(args)
+
+        file_path_train = glob.glob(self.__get_rel_path('*-train.txt'))[0]
+        file_path_test = glob.glob(self.__get_rel_path('*-test.txt'))[0]
+        with open(file_path_train, 'r') as f:
+            lines = f.readlines()
+            self.assertGreater(len(lines), 0)
+
+        with open(file_path_test, 'r') as f:
+            lines = f.readlines()
+            self.assertGreater(len(lines), 0)
+
+        os.remove(file_path_train)
+        os.remove(file_path_test)

--- a/mimic_iii_explorer_client/utils/cli_args_types.py
+++ b/mimic_iii_explorer_client/utils/cli_args_types.py
@@ -4,5 +4,12 @@ import os
 
 def dir_path(path: str) -> str:
     if not os.path.isdir(path):
-        raise argparse.ArgumentTypeError('Path must specify a directory')
+        raise argparse.ArgumentTypeError('Path must specify a directory.')
     return path
+
+
+def train_size(value):
+    value = float(value)
+    if value < 0.0 or value > 1.0:
+        raise argparse.ArgumentTypeError("Train set decimal fraction size should be between 0.0 and 1.0.")
+    return value


### PR DESCRIPTION
Closes #31